### PR TITLE
Add status attribute to item and adds if logic so that retired items …

### DIFF
--- a/app/controllers/carts_controller.rb
+++ b/app/controllers/carts_controller.rb
@@ -10,6 +10,7 @@ class CartsController < ApplicationController
 
   def show
     @cart = Cart.new(session[:cart])
+		byebug
   end
 
   def update

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -2,4 +2,6 @@ class Item < ApplicationRecord
   belongs_to :category
   has_many :orders_items
   has_many :orders, through: :orders_items
+
+	enum status: [:active, :retired]
 end

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -2,6 +2,10 @@
 <h1>Items</h1>
 <% @items.each do |item| %>
 <%= item.title %>
-<%= link_to "Add to Cart", cart_path(item_id: item.id), method: :post %>
+	<% if item.active? %>
+		<%= link_to "Add to Cart", cart_path(item_id: item.id), method: :post %>
+	<% else %>
+		<p>Item Retired</p>
+	<% end %>
 <% end %>
 <%= link_to "View Cart", "/cart" %>

--- a/db/migrate/20171101223236_add_status_to_items.rb
+++ b/db/migrate/20171101223236_add_status_to_items.rb
@@ -1,0 +1,5 @@
+class AddStatusToItems < ActiveRecord::Migration[5.1]
+  def change
+    add_column :items, :status, :integer, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171101194334) do
+ActiveRecord::Schema.define(version: 20171101223236) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -30,6 +30,7 @@ ActiveRecord::Schema.define(version: 20171101194334) do
     t.bigint "category_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "status", default: 0
     t.index ["category_id"], name: "index_items_on_category_id"
   end
 

--- a/spec/features/user_can_add_something_to_cart_spec.rb
+++ b/spec/features/user_can_add_something_to_cart_spec.rb
@@ -12,6 +12,7 @@ describe "When I visit any page with an item on it" do
 
     click_on "View Cart"
 
+
     expect(current_path).to eq "/cart"
     expect(page).to have_content(item.title) 
   end

--- a/spec/features/user_cannot_add_retired_item_to_cart_spec.rb
+++ b/spec/features/user_cannot_add_retired_item_to_cart_spec.rb
@@ -1,0 +1,11 @@
+describe "When a user goes to the show page of a retired item" do
+	it "they cannot add it to their cart" do 
+		category = Category.create(title: "Breakfast")
+    item = category.items.create(title: "Soggy Cereal", description: "Kinda gross", price: 1.25, image: "asdfs", status: 1)
+
+    visit items_path
+
+		expect(page).to_not have_content("Add to Cart")
+		expect(page).to have_content("Item Retired")
+	end 
+end 


### PR DESCRIPTION
…cannot be added to carts

Related Issue: #14 

Summary: Add status attribute to item and adds if logic so that retired items cannot be added to cart

Author(s): @aschreck @randy-darsh @MiguelSilva1997 
