### PR TITLE
Replace form quantity with + -  button

### DIFF
--- a/app/controllers/carts_controller.rb
+++ b/app/controllers/carts_controller.rb
@@ -25,4 +25,19 @@ class CartsController < ApplicationController
     flash[:notice] = %Q[Successfully removed <a href="/items/#{item.id}">#{item.title}</a> from your cart.]
     redirect_to cart_path
   end
+
+	def add
+		value = session[:cart][params["item_id"]]
+		session[:cart][params["item_id"]] = value + 1  
+    redirect_to cart_path
+	end 
+
+	def subtract
+		value = session[:cart][params["item_id"]]
+		session[:cart][params["item_id"]] = value - 1  
+		if session[:cart][params["item_id"]] == 0
+			session[:cart].delete(params[:item_id])
+		end 
+    redirect_to cart_path
+	end 
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,7 +1,6 @@
 require "will_paginate"
 class ItemsController < ApplicationController
   def index
-    #@items = Item.all
     @items = Item.paginate(page: params[:page], per_page: 30)
   end
 end

--- a/app/views/carts/show.html.erb
+++ b/app/views/carts/show.html.erb
@@ -7,7 +7,8 @@
 	<%= @cart.contents[item.id.to_s] %>
   <%= item.image %>
   <%= link_to "Remove", cart_path(item_id: item.id), method: :delete %>
-	<%= render partial: "form", locals: {item: item} %>
+	<%= button_to "+", cart_add_path(item_id: item.id), method: :patch%>
+	<%= button_to "-", cart_subtract_path(item_id: item.id), method: :patch%>
 <% end %>
 
 <h3>Total Price: <%=number_to_currency(@cart.total)%></h3>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,9 +12,11 @@ Rails.application.routes.draw do
   resources :users, only: [:new, :create, :edit, :update]
   resources :orders, only: [:index, :show, :create]
 
-  get '/dashboard', to: "base#dashboard"
-  get '/login', to: 'sessions#new'
-  post '/login', to: 'sessions#create'
-  delete '/logout', to: 'sessions#destroy'
-  get '/:title', to: 'categories#show'
+  get    '/dashboard',     to: "base#dashboard"
+  get    '/login',         to: 'sessions#new'
+  post   '/login',         to: 'sessions#create'
+  delete '/logout',        to: 'sessions#destroy'
+  get    '/:title',        to: 'categories#show'
+	patch  '/cart/add',      to: "carts#add"
+	patch	 '/cart/subtract', to: "carts#subtract"  
 end

--- a/spec/features/user_can_check_out_spec.rb
+++ b/spec/features/user_can_check_out_spec.rb
@@ -22,6 +22,7 @@ describe "When a user adds items to their cart and visits cart page" do
 		click_on "Add to Cart"
 
 		visit "/cart"
+		byebug
 
 		click_on "Checkout"
 


### PR DESCRIPTION
Related Issue: #58 

Summary: Added + or - button to cart—when quantity is 0, it deletes it.

Author(s): @aschreck
